### PR TITLE
Added perform_through to allow push different jobs to a named queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,37 @@ DataJob.perform_async("asdf") # immediately perform asynchronously
 DataJob.perform_in(60, "asdf") # `perform` will be executed 60 sec. later
 ```
 
+#### Queue up Jobs in a named queue
+
+In some cases you want to schedule different jobs in a specific queue and sometimes with specific order. Use the `perform_through`
+with a hash that defines the options for the queue.
+
+The options could contain the following keys
+
+* queue (queue name)
+* workers (number of workers)
+* max jobs (number of max jobs)
+
+Note: if the queue name is already defined workers and max_jobs will not be overwritten, Otherwise A new queue will be created
+
+``` ruby
+class DataJob
+  include SuckerPunch::Job
+
+  def perform(data)
+    puts data
+  end
+end
+
+options = {
+  queue: 'data_queue',
+  workers: 2, # default is 1
+  max_jobs: 10 # default is Unlimited
+}
+DataJob.perform_through(options, "asdf") # Job will be queued and `perform` will be executed when worker picks it up.
+```
+
+
 #### `ActiveRecord` Connection Pool Connections
 
 Jobs interacting with `ActiveRecord` should take special precaution not to

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -49,10 +49,13 @@ module SuckerPunch
       end
       ruby2_keywords(:perform_in) if respond_to?(:ruby2_keywords, true)
 
-      def perform_through(queue, *args)
+      def perform_through(options, *args)
         return unless SuckerPunch::RUNNING.true?
-        job_queue = SuckerPunch::Queue.find_or_create(queue, 1, nil)
-        job_queue.post { __run_perform(queue, *args) }
+        queue_name = options[:queue] || self.to_s
+        workers_count = options[:workers] || 1
+        max_jobs = options[:max_jobs]
+        queue = SuckerPunch::Queue.find_or_create(queue_name, workers_count, max_jobs)
+        queue.post { __run_perform(queue_name, *args) }
       end
       ruby2_keywords(:perform_through) if respond_to?(:ruby2_keywords, true)
 

--- a/lib/sucker_punch/job.rb
+++ b/lib/sucker_punch/job.rb
@@ -35,7 +35,7 @@ module SuckerPunch
       def perform_async(*args)
         return unless SuckerPunch::RUNNING.true?
         queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, num_jobs_max)
-        queue.post { __run_perform(*args) }
+        queue.post { __run_perform(self.to_s, *args) }
       end
       ruby2_keywords(:perform_async) if respond_to?(:ruby2_keywords, true)
 
@@ -43,11 +43,18 @@ module SuckerPunch
         return unless SuckerPunch::RUNNING.true?
         queue = SuckerPunch::Queue.find_or_create(self.to_s, num_workers, num_jobs_max)
         job = Concurrent::ScheduledTask.execute(interval.to_f, args: args, executor: queue) do
-          __run_perform(*args)
+          __run_perform(self.to_s, *args)
         end
         job.pending?
       end
       ruby2_keywords(:perform_in) if respond_to?(:ruby2_keywords, true)
+
+      def perform_through(queue, *args)
+        return unless SuckerPunch::RUNNING.true?
+        job_queue = SuckerPunch::Queue.find_or_create(queue, 1, nil)
+        job_queue.post { __run_perform(queue, *args) }
+      end
+      ruby2_keywords(:perform_through) if respond_to?(:ruby2_keywords, true)
 
       def workers(num)
         self.num_workers = num
@@ -57,18 +64,18 @@ module SuckerPunch
         self.num_jobs_max = num
       end
 
-      def __run_perform(*args)
-        SuckerPunch::Counter::Busy.new(self.to_s).increment
+      def __run_perform(queue, *args)
+        SuckerPunch::Counter::Busy.new(queue).increment
 
         result = self.new.perform(*args)
 
-        SuckerPunch::Counter::Processed.new(self.to_s).increment
+        SuckerPunch::Counter::Processed.new(queue).increment
         result
       rescue => ex
-        SuckerPunch::Counter::Failed.new(self.to_s).increment
+        SuckerPunch::Counter::Failed.new(queue).increment
         SuckerPunch.exception_handler.call(ex, self, [*args])
       ensure
-        SuckerPunch::Counter::Busy.new(self.to_s).decrement
+        SuckerPunch::Counter::Busy.new(queue).decrement
       end
       ruby2_keywords(:__run_perform) if respond_to?(:ruby2_keywords, true)
     end

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -22,7 +22,12 @@ module SuckerPunch
     def test_perform_through_runs_in_named_queue_asynchronously
       arr = Concurrent::Array.new
       latch = Concurrent::CountDownLatch.new
-      FakeLatchJob.perform_through('latchqueue', arr, latch)
+      options = {
+        queue: 'latchqueue',
+        workers: 3
+      }
+      FakeLatchJob.perform_through(options, arr, latch)
+      binding.pry
       latch.wait(1)
       assert_equal 1, arr.size
     end

--- a/test/sucker_punch/job_test.rb
+++ b/test/sucker_punch/job_test.rb
@@ -19,6 +19,14 @@ module SuckerPunch
       assert_equal 1, arr.size
     end
 
+    def test_perform_through_runs_in_named_queue_asynchronously
+      arr = Concurrent::Array.new
+      latch = Concurrent::CountDownLatch.new
+      FakeLatchJob.perform_through('latchqueue', arr, latch)
+      latch.wait(1)
+      assert_equal 1, arr.size
+    end
+
     def test_job_isnt_run_with_perform_async_if_sucker_punch_is_shutdown
       SuckerPunch::RUNNING.make_false
       arr = Concurrent::Array.new
@@ -85,7 +93,7 @@ module SuckerPunch
     end
 
     def test_run_perform_delegates_to_instance_perform
-      assert_equal "fake", FakeLogJob.__run_perform
+      assert_equal "fake", FakeLogJob.__run_perform(self.to_s)
     end
 
     def test_busy_workers_is_incremented_during_job_execution


### PR DESCRIPTION
## Defined Problem

I've been working lately on a project which heavily depends on asynchronous background jobs, I was facing a case where I needed to have more control on jobs queue.

Currently the gem finds or creates a queue based on the job class name, for my case some jobs must be queued under certain scopes so 2 different jobs with the same scope cannot be running at the same time.

## Suggested Solution

Through reading the code of this gem, I found that we could have a new functionality that allows us to push a job to a new or an already named queue.

This will allow me to have more vision and control of when and where async jobs gets executed.

## Changes Introduced

The main Idea is to add a function called `perform_through` which take a first argument of the queue options as described below: - 

``` ruby
class DataJob
  include SuckerPunch::Job

  def perform(data)
    puts data
  end
end

options = {
  queue: 'data_queue', # default is class name
  workers: 2, # default is 1
  max_jobs: 10 # default is Unlimited
}
DataJob.perform_through(options, "asdf") # Job will be queued and `perform` will be executed when worker picks it up.
```
If the queue is not defined it will be created with given options. Otherwise, it will just push the job to it.